### PR TITLE
Correcting for the warning that occurs

### DIFF
--- a/quantiacsToolbox/quantiacsToolbox.py
+++ b/quantiacsToolbox/quantiacsToolbox.py
@@ -29,6 +29,8 @@ from mpl_toolkits.mplot3d import Axes3D, proj3d
 
 import pandas as pd
 import numpy as np
+#new addition
+np.seterr(divide='ignore')
 
 try:
     import tkinter as tk


### PR DESCRIPTION
The following warning occurs:
E:\Anaconda\lib\site-packages\quantiacsToolbox\quantiacsToolbox.py:881: RuntimeWarning: invalid value encountered in true_divide
  position = position / np.sum(abs(position))
I tried to correct that using numpy.seterr() [added in line 32]


